### PR TITLE
DBCD branch migration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "DBDiffer"]
 	path = DBDiffer
 	url = https://github.com/barncastle/DBDiffer
+[submodule "DBCD"]
+	path = DBCD
+	url = https://github.com/wowdev/DBCD.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "DBDiffer"]
 	path = DBDiffer
 	url = https://github.com/barncastle/DBDiffer
-[submodule "DBCD"]
-	path = DBCD
-	url = https://github.com/barncastle/DBCD.git

--- a/DBCDumpHost/Controllers/DiffController.cs
+++ b/DBCDumpHost/Controllers/DiffController.cs
@@ -27,8 +27,8 @@ namespace DBCDumpHost.Controllers
 
             Logger.WriteLine("Serving diff for " + name + " between " + build1 + " and " + build2);
 
-            var dbc1 = dbcManager.GetOrLoad(name, build1, useHotfixesFor1).BackingCollection;
-            var dbc2 = dbcManager.GetOrLoad(name, build2, useHotfixesFor2).BackingCollection;
+            var dbc1 = (IDictionary)dbcManager.GetOrLoad(name, build1, useHotfixesFor1);
+            var dbc2 = (IDictionary)dbcManager.GetOrLoad(name, build2, useHotfixesFor2);
 
             var comparer = new DBComparer(dbc1, dbc2);
             WoWToolsDiffResult diff = (WoWToolsDiffResult)comparer.Diff(DiffType.WoWTools);


### PR DESCRIPTION
PR includes updating to the master branch of DBCD and removing the `BackingCollection` field.

As far as I can tell, performance-wise the speed difference is negligible, there is a few ms more overhead than before where JSON.net is serialising a dynamic opposed to a struct. 