### PR TITLE
Add flags support to data filters

### DIFF
--- a/DBCDumpHost/config.json
+++ b/DBCDumpHost/config.json
@@ -1,7 +1,7 @@
 ﻿{
     "config": {
         "dbcdir": "Z:/DBCs",
-        "definitionsdir": "../WoWDBDefs/definitions"
+        "definitionsdir": "../WoWDBDefs/definitions",
         "cascToolHost":  "https://wow.tools"
     }
 }


### PR DESCRIPTION
This allows filtering flag-like columns using hexadecimal filter strings to reduce the result set to rows matching all specified flags. For example, filtering the Achievement tables' Flags field with the string "0x1004" will only return rows that have those bits set in the field.

In its current implementation flags matching is exhaustive; a filter of "0x1004" requires that *both* the 0x1000 and 0x4 bits be set for a row to pass the filter. This is probably the more desirable default logic; I didn't want to over-complicate things by supporting an OR style search where "0x1004" could instead return rows where *either* bit is set.

If a user attempts to filter the flags of a non-numeric field then an exception will bubble up to the request handler and no rows will be returned. This is the same behavior that a malformed regex search would result in.

Naturally I don't quite have a complete local setup to test this in; I did manage to hack something together and did some basic tests though it all seems to work fine (including regex/exact/default filter behaviors). I also haven't C#'d since about 2012 so if there's anything that sticks out then let me know.