### PR TITLE
DB Data Refactor

### DIFF
--- a/DBCDumpHost/Controllers/DataController.cs
+++ b/DBCDumpHost/Controllers/DataController.cs
@@ -177,25 +177,27 @@ namespace DBCDumpHost.Controllers
                     }
                 }
 
-                var sorted = storage.Values.ToList();
-
-                // TODO: Support sorting by array fields (sortByArrayKey)
+                List<DBCDRow> sorted;
                 if(sorting && !string.IsNullOrWhiteSpace(sortByName) && !sortByName.EndsWith("]"))
                 {
                     if(sortDesc == "asc")
                     {
                         if (sortByArrayKey.HasValue)
-                            sorted = sorted.OrderBy(row => ((Array)row[sortByName]).GetValue(sortByArrayKey.Value)).ToList();
+                            sorted = storage.Values.OrderBy(row => ((Array)row[sortByName]).GetValue(sortByArrayKey.Value)).ToList();
                         else
-                            sorted = sorted.OrderBy(row => row[sortByName]).ToList();
+                            sorted = storage.Values.OrderBy(row => row[sortByName]).ToList();
                     }
                     else
                     {
                         if (sortByArrayKey.HasValue)
-                            sorted = sorted.OrderByDescending(row => ((Array)row[sortByName]).GetValue(sortByArrayKey.Value)).ToList();
+                            sorted = storage.Values.OrderByDescending(row => ((Array)row[sortByName]).GetValue(sortByArrayKey.Value)).ToList();
                         else
-                            sorted = sorted.OrderByDescending(row => row[sortByName]).ToList();
+                            sorted = storage.Values.OrderByDescending(row => row[sortByName]).ToList();
                     }
+                }
+                else
+                {
+                    sorted = storage.Values.ToList();
                 }
 
                 var resultCount = 0;
@@ -345,7 +347,7 @@ namespace DBCDumpHost.Controllers
             {
                 if(field is int)
                 {
-                    field = BitConverter.ToUInt32(BitConverter.GetBytes((int)field));
+                    field = unchecked((uint)field);
                 }
 
                 var num = Convert.ToUInt64(field, CultureInfo.InvariantCulture);

--- a/DBCDumpHost/Controllers/DataController.cs
+++ b/DBCDumpHost/Controllers/DataController.cs
@@ -68,7 +68,7 @@ namespace DBCDumpHost.Controllers
                     parameters.Add(get.Key, get.Value);
             }
 
-            if (!parameters.TryGetValue("search[value]", out var searchValue))
+            if (!parameters.TryGetValue("search[value]", out var searchValue) || string.IsNullOrWhiteSpace(searchValue))
             {
                 Logger.WriteLine("Serving data " + start + "," + length + " for dbc " + name + " (" + build + ") for draw " + draw);
             }

--- a/DBCDumpHost/Utils/DBCViewFilter.cs
+++ b/DBCDumpHost/Utils/DBCViewFilter.cs
@@ -1,0 +1,267 @@
+﻿using DBCD;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace DBCDumpHost.Utils
+{
+    public class DBCViewFilter
+    {
+        public bool Searching { get; private set; }
+        public bool Filtering { get; private set; }
+        public bool Sorting { get; private set; }
+        public string SearchValue { get; private set; }
+        public string SortDirection { get; private set; }
+
+        private readonly IDBCDStorage Storage;
+        private readonly IReadOnlyDictionary<string, string> Parameters;
+        private readonly Func<string, string> StringFormatter;
+        private int SortBySiteCol;
+
+        private static readonly MethodInfo ObjectToString = typeof(object).GetMethod("ToString");
+
+        private Func<DBCDRow, bool> FilterFunc;
+        private Func<DBCDRow, object> SortFunc;
+        private Func<DBCDRow, string[]> ConverterFunc;
+
+        public DBCViewFilter(IDBCDStorage storage, IReadOnlyDictionary<string, string> parameters, Func<string, string> stringFormatter = null)
+        {
+            Storage = storage;
+            Parameters = parameters;
+            StringFormatter = stringFormatter;
+
+            InitaliseSort();
+            InitaliseSearch();
+            Initalise();
+        }
+
+        /// <summary>
+        /// Returns the result set of formatted records filtered and sorted accordingly
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public IEnumerable<string[]> GetRecords(CancellationToken? token = null)
+        {
+            var records = Storage.Values.AsEnumerable();
+
+            // apply sort
+            if (SortFunc != null)
+            {
+                if (SortDirection == "asc")
+                    records = records.OrderBy(SortFunc);
+                else
+                    records = records.OrderByDescending(SortFunc);
+            }
+
+            // apply filter
+            if (FilterFunc != null)
+            {
+                records = records.Where(FilterFunc);
+            }
+
+            // apply converter
+            var result = records.Select(ConverterFunc);
+
+            foreach (var rowList in result)
+            {
+                token?.ThrowIfCancellationRequested();
+
+                // if searching we need to futher filter the returned records for SearchValue
+                var matches = !Searching;
+                for (var i = 0; !matches && i < rowList.Length; i++)
+                    matches = rowList[i].Contains(SearchValue, StringComparison.InvariantCultureIgnoreCase);
+
+                if (matches)
+                    yield return rowList;
+            }
+        }
+
+
+        /// <summary>
+        /// Creates the Sort, Where and Converter functions from the provided parameters
+        /// </summary>
+        private void Initalise()
+        {
+            var param = Expression.Parameter(typeof(DBCDRow), "row");
+            var properties = new List<Expression>();
+            var filters = new Dictionary<Expression, Predicate<object>>(); // [DBCDRow.Property, Predicate]
+
+            var firstItem = Storage.Values.First();
+            var siteColIndex = 0;
+
+            for (var i = 0; i < Storage.AvailableColumns.Length; ++i)
+            {
+                var field = firstItem[Storage.AvailableColumns[i]];
+                var size = 1;
+                var isArray = false;
+
+                if (field is Array array)
+                {
+                    size = array.Length;
+                    isArray = true;
+                }
+
+                for (var j = 0; j < size; j++)
+                {
+                    var property = GetProperty(param, Storage.AvailableColumns[i], isArray, j);
+
+                    if (SortBySiteCol == siteColIndex)
+                    {
+                        SortFunc = Expression.Lambda<Func<DBCDRow, object>>(property, param).Compile();
+                    }
+
+                    if (Parameters.TryGetValue("columns[" + siteColIndex + "][search][value]", out var filterVal) && !string.IsNullOrWhiteSpace(filterVal))
+                    {
+                        filters.Add(property, CreateFilterPredicate(filterVal));
+                    }
+
+                    // cast to string and apply any custom string formatting i.e. HtmlEncode and StringToCSVCell
+                    var formattedProperty = Expression.Call(property, ObjectToString);
+                    if (StringFormatter != null && field.GetType() == typeof(string))
+                    {
+                        formattedProperty = Expression.Call(StringFormatter.Method, formattedProperty);
+                    }
+
+                    properties.Add(formattedProperty);
+                    siteColIndex++;
+                }
+            }
+
+            // compile the filter predicate
+            if (filters.Count > 0)
+            {
+                Searching = false; // NOTE: remove this line to allow filtered searches
+                Filtering = true;
+                CreateFilterFunc(param, filters);
+            }
+
+            // compile the DBCDRow to string[] converter
+            CreateConverterFunc(param, properties);
+        }
+
+        /// <summary>
+        /// Attempts to parse the sorted column and it's direction - if any
+        /// </summary>
+        /// <returns></returns>
+        private void InitaliseSort()
+        {
+            SortBySiteCol = -1;
+
+            if (Parameters.TryGetValue("order[0][column]", out var sortbycol))
+            {
+                if (int.TryParse(sortbycol, out var sortBySiteCol))
+                {
+                    SortDirection = Parameters["order[0][dir]"];
+                    SortBySiteCol = sortBySiteCol;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to parse and normalise the search value - if any
+        /// </summary>
+        /// <returns></returns>
+        private void InitaliseSearch()
+        {
+            if (Parameters.TryGetValue("search[value]", out var searchValue) && !string.IsNullOrEmpty(searchValue))
+            {
+                Searching = true;
+
+                // format the searchvalue so it matches in GetRecords
+                if (StringFormatter != null)
+                    SearchValue = StringFormatter(searchValue);
+                else
+                    SearchValue = searchValue;
+            }
+            else
+            {
+                Searching = false;
+            }
+        }
+
+        #region Predicates
+
+        private static Predicate<object> CreateFilterPredicate(string filterVal)
+        {
+            if (filterVal.StartsWith("exact:"))
+            {
+                return CreateRegexPredicate("^" + filterVal.Remove(0, 6) + "$");
+            }
+            else if (filterVal.StartsWith("regex:"))
+            {
+                return CreateRegexPredicate(filterVal.Remove(0, 6));
+            }
+            else if (filterVal.StartsWith("0x"))
+            {
+                if (ulong.TryParse(filterVal.Remove(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ulong flags))
+                {
+                    return CreateFlagsPredicate(flags);
+                }
+            }
+
+            // Fallback logic is kept outside of an `else` branch to permit invalid filter recovery.
+            return CreateRegexPredicate(filterVal);
+        }
+
+        private static Predicate<object> CreateRegexPredicate(string pattern)
+        {
+            var re = new Regex(pattern);
+            return (field) => re.IsMatch(field.ToString());
+        }
+
+        private static Predicate<object> CreateFlagsPredicate(ulong flags)
+        {
+            return (field) =>
+            {
+                if (field is int)
+                {
+                    field = unchecked((uint)field);
+                }
+
+                var num = Convert.ToUInt64(field, CultureInfo.InvariantCulture);
+                return (num & flags) == flags;
+            };
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private void CreateFilterFunc(ParameterExpression param, Dictionary<Expression, Predicate<object>> filters)
+        {
+            Expression expression = Expression.Constant(true); // null check avoidance
+            foreach (var filter in filters)
+            {
+                var call = Expression.Invoke(Expression.Constant(filter.Value), filter.Key);
+                expression = Expression.AndAlso(expression, call);
+            }
+
+            var lambda = Expression.Lambda<Func<DBCDRow, bool>>(expression, param);
+
+            FilterFunc = lambda.Compile();
+        }
+
+        private void CreateConverterFunc(ParameterExpression param, ICollection<Expression> properties)
+        {
+            var expression = Expression.NewArrayInit(typeof(string), properties);
+            var lambda = Expression.Lambda<Func<DBCDRow, string[]>>(expression, param);
+
+            ConverterFunc = lambda.Compile();
+        }
+
+        private static Expression GetProperty(ParameterExpression param, string fieldname, bool isArray, int index = 0)
+        {
+            if (isArray)
+                return Expression.Property(param, "Item", Expression.Constant(fieldname), Expression.Constant(index));
+            else
+                return Expression.Property(param, "Item", Expression.Constant(fieldname));
+        }
+
+        #endregion
+    }
+}

--- a/DBCDumpHost/Utils/DBCViewFilter.cs
+++ b/DBCDumpHost/Utils/DBCViewFilter.cs
@@ -218,9 +218,9 @@ namespace DBCDumpHost.Utils
         {
             return (field) =>
             {
-                if (field is int)
+                if (field is int @int)
                 {
-                    field = unchecked((uint)field);
+                    field = unchecked((uint)@int);
                 }
 
                 var num = Convert.ToUInt64(field, CultureInfo.InvariantCulture);

--- a/DBCDumpHost/Utils/DBCViewFilter.cs
+++ b/DBCDumpHost/Utils/DBCViewFilter.cs
@@ -168,7 +168,7 @@ namespace DBCDumpHost.Utils
         /// <returns></returns>
         private void InitaliseSearch()
         {
-            if (Parameters.TryGetValue("search[value]", out var searchValue) && !string.IsNullOrEmpty(searchValue))
+            if (Parameters.TryGetValue("search[value]", out var searchValue) && !string.IsNullOrWhiteSpace(searchValue))
             {
                 Searching = true;
 

--- a/DBCDumpHost/Utils/DBCViewFilter.cs
+++ b/DBCDumpHost/Utils/DBCViewFilter.cs
@@ -35,9 +35,9 @@ namespace DBCDumpHost.Utils
             Parameters = parameters;
             StringFormatter = stringFormatter;
 
-            InitaliseSort();
-            InitaliseSearch();
-            Initalise();
+            InitialiseSort();
+            InitialiseSearch();
+            Initialise();
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace DBCDumpHost.Utils
         /// <summary>
         /// Creates the Sort, Where and Converter functions from the provided parameters
         /// </summary>
-        private void Initalise()
+        private void Initialise()
         {
             var param = Expression.Parameter(typeof(DBCDRow), "row");
             var properties = new List<Expression>();
@@ -148,7 +148,7 @@ namespace DBCDumpHost.Utils
         /// Attempts to parse the sorted column and it's direction - if any
         /// </summary>
         /// <returns></returns>
-        private void InitaliseSort()
+        private void InitialiseSort()
         {
             SortBySiteCol = -1;
 
@@ -166,7 +166,7 @@ namespace DBCDumpHost.Utils
         /// Attempts to parse and normalise the search value - if any
         /// </summary>
         /// <returns></returns>
-        private void InitaliseSearch()
+        private void InitialiseSearch()
         {
             if (Parameters.TryGetValue("search[value]", out var searchValue) && !string.IsNullOrWhiteSpace(searchValue))
             {
@@ -174,9 +174,9 @@ namespace DBCDumpHost.Utils
 
                 // format the searchvalue so it matches in GetRecords
                 if (StringFormatter != null)
-                    SearchValue = StringFormatter(searchValue);
+                    SearchValue = StringFormatter(searchValue.Trim());
                 else
-                    SearchValue = searchValue;
+                    SearchValue = searchValue.Trim();
             }
             else
             {


### PR DESCRIPTION
Right so this is quite a big change to the system which you may or may not want (feel free to discard)!

I saw your pain of accessing arrays and loops and decided to have a crack at converting this to expressions as so to avoid both these issues and improve performance. I then saw issue #4 and took the above one step further to support partial exports (frontend needs changing to support this obviously) which resulted in shifting most of the code to a new class (`DBCViewFilter`) which is used by both, data and export, controllers.

`DBCViewFilter` compiles three functions, one for sorting, one for filtering and one for converting a `DBCDRow` directly to a formatted `string[]` - as well as filtering the search term as before. These then get applied when  `GetRecords` is called returning the final dataset directly.

For the three functions:
- `SortFunc` is literally just a property accessor which compiles to: `.OrderBy(row => row["Text_lang"])`
- `FilterFunc` is an additive filter that uses your previous predicate system which compiles to: `.Where(row => True && .Invoke Predicate<Object>(row.Item["Text_lang"]) && …)`
- `ConvertFunc` generates a `string[]` with html encoding/csv quoting pre-applied which compiles to:
```
 .NewArray String[] {
    .Call System.Net.WebUtility.HtmlEncode(.Call ($row.Item["Text_lang"]).ToString()), // formatting of string fields
    …
    .Call ($row.Item["ID"]).ToString(), // standard fields as strings
    …
    .Call ($row.Item["EmoteDelay",0]).ToString(), // arrays exploded and as strings
    .Call ($row.Item["EmoteDelay",1]).ToString(),
    …
 }
```

In regards to performance. The main increase comes from the loop removal as well as some short-cutting I've added. I've run several queries, 20 times across 3 different DBs and averaged the times as per below. I used 1 small db (PowerTypes - 10s of records), 1 medium (BroadcastText - 1000s of records) and 1 large (SpellEffect - 100,000s of records) to give a better spread. (The small db performed +/- 1 ms in every test so isn't included below).

|  (measured in milliseconds)  | broadcasttext | -      |         | spelleffect | -       |         |         |
| ---------------------------------- | ------------- | ------ | ------- | ----------- | ------- | ------- | ------- |
| cold start                         | 1834.1        | **1423.3** | -22.40% | **7768**        | 9047.6  | 16.47%  | -2.96%  |
| warm start                         | **43.2**          | 48.1   | 11.34%  | **3452.05**     | 4831    | 39.95%  | 25.64%  |
| search function                    | **54.6**          | 59.9   | 9.71%   | **5427.75**     | 7993.4  | 47.27%  | 28.49%  |
| search + sort                      | **28.05**         | 45     | 60.43%  | **5819.1**     | 7869.5  | 35.24%  | 47.83%  |
| filter + sort                      | **56.1**          | 62.85  | 12.03%  | **1295.45**     | 4681.8  | 261.40% | 136.72% |
| filter + sort (multiple inc array) | **28.1**          | 47     | 67.26%  | **673.4**       | 4895.05 | 626.92% | 347.09% |
|                                    | NEW           | OLD    | DIFF    | NEW         | OLD     | DIFF    | MEDIAN  |

The only downside to this is that initial load (cold start) of compiling the `ConverterFunc` is slow and adds ~20% for the very first load - although this is negated at a certain record count. I also tested the export controller and that is ~12% faster but that's not important.

There's also some additional features and notes that I wasn't sure about:
1. by deleting line 138 in `DBCViewFilter` you can enable combined searching and filtering
2. if `newLinesInStrings` is obsolete the export controller can be simplified a little bit
3. to support partial exports you'll need to throw a POST request at the export controller containing the datatable params which can be gotten by `JSON.stringify($('#dbtable').DataTable().ajax.params());`
4. I've not support multi-sort but can do if needed