### PR TITLE
Fix spell range

### DIFF
--- a/DBCDumpHost/Utils/SpellDataSupplier.cs
+++ b/DBCDumpHost/Utils/SpellDataSupplier.cs
@@ -227,7 +227,7 @@ namespace DBCDumpHost.Utils
                 return null;
             }
 
-            var spellRangeID = (ushort)spellMiscRow[0]["DurationIndex"];
+            var spellRangeID = (ushort)spellMiscRow[0]["RangeIndex"];
             if (spellRangeID == 0)
             {
                 Console.WriteLine("Unable to find range for Spell ID " + spellID);
@@ -244,11 +244,9 @@ namespace DBCDumpHost.Utils
                     return (int)rangeMin[0];
                 }
 
-                var rangeMax = rangeRow.FieldAs<float[]>("RangeMax");
-
-                if ((int)rangeMax[0] != 0)
+                if ((int)rangeMin[1] != 0)
                 {
-                    return (int)rangeMax[0];
+                    return (int)rangeMin[1];
                 }
             }
 
@@ -264,7 +262,7 @@ namespace DBCDumpHost.Utils
                 return null;
             }
 
-            var spellRangeID = (ushort)spellMiscRow[0]["DurationIndex"];
+            var spellRangeID = (ushort)spellMiscRow[0]["RangeIndex"];
             if (spellRangeID == 0)
             {
                 Console.WriteLine("Unable to find range for Spell ID " + spellID);
@@ -281,11 +279,9 @@ namespace DBCDumpHost.Utils
                     return (int)rangeMax[0];
                 }
 
-                var rangeMin = rangeRow.FieldAs<float[]>("RangeMin");
-
-                if ((int)rangeMin[0] != 0)
+                if ((int)rangeMax[1] != 0)
                 {
-                    return (int)rangeMin[0];
+                    return (int)rangeMax[1];
                 }
             }
 

--- a/WoWTools.SpellDescParser/SpellDescParser.cs
+++ b/WoWTools.SpellDescParser/SpellDescParser.cs
@@ -229,10 +229,10 @@ namespace WoWTools.SpellDescParser
                     type = PropertyType.ProcCharges;
                     break;
                 case 'r': // SpellRange::ID
-                    type = PropertyType.MinRange;
+                    type = PropertyType.MaxRange;
                     break;
                 case 'R': // SpellRange::ID
-                    type = PropertyType.MaxRange;
+                    type = PropertyType.MinRange;
                     break;
                 case 's': // Effect
                     type = PropertyType.Effect;


### PR DESCRIPTION
- Use the RangeIndex (DurationIndex was COMPLETELY wrong)
- Use index 0 or 1, don't try to bump it down to the oposite value if its 0